### PR TITLE
showalicense.com 1.1.0 Improved documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ make the life easier and will avoid wasting time on things which are not
 requested. :sparkles:
 
 ## Discuss the changes before doing them
- - First of all, open an issue in the repository, using the bug tracker ,
+ - First of all, open an issue in the repository, using the [bug tracker][1],
    describing the contribution you would like to make, the bug you found or any
    other ideas you have. This will help us to get you started on the right
    foot.
@@ -58,5 +58,7 @@ Finally, your contributions will be merged, and everyone will be happy! :smile:
 Contributions are more than welcome!
 
 Thanks! :sweat_smile:
+
+[1]: https://github.com/IonicaBizau/showalicense.com/issues
 
 [2]: https://github.com/IonicaBizau/code-style

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "showalicense.com",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A site to provide an easy way to show licenses and their human-readable explanations.",
   "main": "lib/index.js",
   "scripts": {
@@ -19,7 +19,9 @@
       {
         "h2": "Your help is needed! :heart:"
       },
-      { "p": "Contribute by explaining licenses. Check out [this issue](https://github.com/IonicaBizau/showalicense.com/issues/1). :memo: :book:" },
+      {
+        "p": "Contribute by explaining licenses. Check out [this issue](https://github.com/IonicaBizau/showalicense.com/issues/1). :memo: :book:"
+      },
       {
         "h2": "Usage"
       },
@@ -83,10 +85,10 @@
       }
     ],
     "thanks": {
-        "ul": [
-            "[github/choosealicense.com](https://github.com/github/choosealicense.com)–a good inspiration source (some ideas and CSS were taken from here) :sparkle:",
-            "[**@Cerberus-tm**](https://github.com/Cerberus-tm)–who had the idea for the site name :cake:"
-        ]
+      "ul": [
+        "[github/choosealicense.com](https://github.com/github/choosealicense.com)–a good inspiration source (some ideas and CSS were taken from here) :sparkle:",
+        "[**@Cerberus-tm**](https://github.com/Cerberus-tm)–who had the idea for the site name :cake:"
+      ]
     }
   },
   "dependencies": {


### PR DESCRIPTION
- Added package.json
- Improved the documentation.
- Integrated **[json2md](https://github.com/IonicaBizau/json2md)** with **[blah](https://github.com/IonicaBizau/blah)** to get the best flexibility in generating documentation. :dizzy:
- Relicense to [MIT and link to the license](http://showalicense.com). :heart:

Regarding the integration of **json2md** into **blah**, [read this blog post I wrote](http://ionicabizau.net/blog/27-how-to-convert-json-to-markdown-using-json2md).
