### PR TITLE
Use full date for the year

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -67,7 +67,7 @@ function renderInfo(c) {
 
     if (data.year) {
         if (data.year < thisYear) {
-            data.year += "-" + thisYear.substring(2);
+            data.year += "-" + thisYear;
         }
     } else {
         delete data.year;


### PR DESCRIPTION
This simply changes the present year to be in the full year format.

I think this is a better way because if you set the starting year to `1999` then the license will show `1999-16` which isn't correct!
