### PR TITLE
Improve the year range

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ Contributions are more than welcome!
 
 Thanks! :sweat_smile:
 
+
+
 [1]: https://github.com/IonicaBizau/showalicense.com/issues
 
 [2]: https://github.com/IonicaBizau/code-style

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 [![showalicense.com](http://i.imgur.com/DEYIE8P.png)](http://showalicense.com/)
 
 # showalicense.com [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/showalicense.com.svg)](https://www.npmjs.com/package/showalicense.com) [![Downloads](https://img.shields.io/npm/dt/showalicense.com.svg)](https://www.npmjs.com/package/showalicense.com) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
@@ -12,10 +13,12 @@ Contribute by explaining licenses. Check out [this issue](https://github.com/Ion
 
 Whether you just want to show a license or see its human-readable explanation, you can use this website. It provides a nice querystring API documented below:
 
+
  - `#license-<license>` (hash): set the license to display
  - `fullname=<name>`: set the copyright holder name
  - `year=<name>`: set the starting copyright yea
  - `hide_explanations=<true|false>` (default: `false`): hide the explanations column
+
 
 [![showalicense.com](http://i.imgur.com/DikgR8H.png)](http://showalicense.com/)
 
@@ -26,14 +29,17 @@ Whether you just want to show a license or see its human-readable explanation, y
  - To set the starting copyright year use the `year` parameter: http://showalicense.com/?year=2013&fullname=Alice#license-mit
  - To hide the explanations column, you have to use `hide_explanations=true`: http://showalicense.com/?hide_explanations=true&year=2013&fullname=Alice#license-mit
 
-## How to contribute
+
+## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 
 ### Explaining a license
 
 Explanations are kept in `txt` files in the [`explanations`](/explanations) directory, having the license names (e.g. `mit.txt`).
 
+
 Contributions in this directions are really appreciated.
+
 
  1. Fork this repository.
  2. Edit the `explanations/<license>.txt` file (you can follow [`explanations/mit.txt`](/explanations/mit.txt) as example).
@@ -44,18 +50,22 @@ Contributions in this directions are really appreciated.
 
 If the license you're searching for is missing, make sure you add it.
 
+
  1. Fork this repository.
  2. Add a new file in the [`licenses`](/licenses) directory, named `<license>.txt` (replace `<license>` with the license name) and then do the same in the [`explanations`](/explanations) directory (you can follow the MIT license example: see [`explanations/mit.txt`](/explanations/mit.txt) and [`licenses/mit.txt`](/licenses/mit.txt)).
  3. Give nice, funny and useful explanation in the `explanations/<license>.txt` file you added.
  4. Add yourself as contributor in [`package.json`](/package.json).
  5. Raise a pull request! :tada:
 
-## Thanks
+
+## :cake: Thanks
 
  - [github/choosealicense.com](https://github.com/github/choosealicense.com)–a good inspiration source (some ideas and CSS were taken from here) :sparkle:
  - [**@Cerberus-tm**](https://github.com/Cerberus-tm)–who had the idea for the site name :cake:
 
-## License
+
+
+## :scroll: License
 
 [MIT][license] © [Ionică Bizău][website]
 

--- a/js/index.js
+++ b/js/index.js
@@ -67,7 +67,7 @@ function renderInfo(c) {
 
     if (data.year) {
         if (data.year < thisYear) {
-            data.year += "-" + thisYear.substring(2);
+            data.year += "-" + thisYear;
         }
     } else {
         delete data.year;

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ var $ = require("elm-select")
   , sameTime = require("same-time")
   , barbe = require("barbe")
   , Err = require("err")
+  , yearRange = require("year-range")
   ;
 
 // Constants
@@ -53,8 +54,7 @@ function showNormalView() {
 
 function renderInfo(c) {
     var data = {}
-      , thisYear = new Date().getFullYear().toString()
-      , startYear = Url.queryString("year")
+      , startYear = parseInt(Url.queryString("year"))
       ;
 
     data.year = startYear;
@@ -65,9 +65,7 @@ function renderInfo(c) {
     }
 
     if (data.year) {
-        if (data.year < thisYear) {
-            data.year += "-" + thisYear.substring(2);
-        }
+        data.year = yearRange(data.year);
     } else {
         delete data.year;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "showalicense.com",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A site to provide an easy way to show licenses and their human-readable explanations.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -94,9 +94,10 @@
   "dependencies": {
     "barbe": "^2.1.0",
     "elm-select": "^1.3.0",
+    "err": "^1.0.0",
     "same-time": "^2.2.0",
     "whatwg-fetch": "^0.10.1",
-    "err": "^1.0.0"
+    "year-range": "^1.1.0"
   },
   "devDependencies": {
     "abs": "^1.1.0",


### PR DESCRIPTION
Bringing @davisonio's idea on the main branch: if the start year is in previous (or another) century, show full year (e.g. `1988-2016` instead of `1988-16`).

For years in the same century it is rendered in the `YYYY-YY` format (e.g. `2001-16`, not `2001-2016`).

This is done using the [`year-range`](https://github.com/IonicaBizau/year-range) module I published recently. :package: 

:gift: Bonus! Re-rendered the README.md. It contains more emojis! :grin: 
